### PR TITLE
allow install of git based packages (pytorch_galaxy_datasets)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /usr/src/zoobot
 
 RUN apt-get update && apt-get -y upgrade && \
   apt-get install --no-install-recommends -y \
-  build-essential && \
+  build-essential \
+  git && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install dependencies


### PR DESCRIPTION
Now we need to install the pytorch_galaxy_datasets package from GH / git we need git in the dockerfile