### PR TITLE
feat(CI): Add proposed python CI GH Action

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,33 @@
+name: "Build and Tests"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ created ]
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.8','3.9', '3.10' ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Test with PyTest
+        run: |
+          pytest -v .


### PR DESCRIPTION
This PR proposes to add a simple GH Action script that establishes a python environment, downloads the requirements and runs `pytest`. 

Some other things to consider might be to use `conda` for virtual environments and creating CI scripts for Docker as well.