### PR TITLE
fix: update broken links in docs

### DIFF
--- a/docs/components/overview.rst
+++ b/docs/components/overview.rst
@@ -109,7 +109,9 @@ Re-use ``preprocess_config`` to ensure your train, validation, test and ultimate
 
 With PyTorch, preprocessing happens in the DataModule you define. 
 Personally, I find this a little simpler.
-See `zoobot/pytorch/datasets/decals_dr8.py <https://github.com/mwalmsley/zoobot/blob/main/zoobot/pytorch/datasets/decals_dr8.py>`_ for a working example to adjust. 
+See `pytorch-galaxy-datasets/pytorch_galaxy_datasets/deprecated/decals_dr8.py
+<https://github.com/mwalmsley/pytorch-galaxy-datasets/blob/main/pytorch_galaxy_datasets/deprecated/decals_dr8.py>`_
+for a working example to adjust. 
 
 .. _overview_training:
 
@@ -148,5 +150,5 @@ Making predictions is then as easy as:
     # the API is the same for TensorFlow and PyTorch, happily
     predictions = model.predict(pred_dataset)
 
-See the end of `finetune_minimal.py <https://github.com/mwalmsley/zoobot/blob/main/finetune_minimal.py>`_ for a complete (TensorFlow) example.
+See the end of `zoobot/tensorflow/examples/finetune_minimal.py <https://github.com/mwalmsley/zoobot/blob/main/zoobot/tensorflow/examples/finetune_minimal.py>`_ for a complete (TensorFlow) example.
 

--- a/docs/data_notes.rst
+++ b/docs/data_notes.rst
@@ -10,7 +10,7 @@ Zoobot includes three datasets you might be interested in:
 - Catalogues of ring galaxies. There are two catalogues: basic, derived from "ring" tags on the Galaxy Zoo forum, or advanced, derived from the GZ DECaLS "ring" vote fraction.
   
 Pretrained weights and representations are available `from Dropbox <https://www.dropbox.com/sh/asqia51m1u3ccl1/AAD2XZz-AtG-ZShLiPRBrRzqa?dl=0>`_.
-Ring catalogs and a subset of galaxy images and are available under the `data <https://github.com/mwalmsley/zoobot/tree/pytorch/data>`_ folder. 
+Ring catalogs and a subset of galaxy images and more are available under the `galaxy-datasets <https://github.com/mwalmsley/pytorch-galaxy-datasets>`_ repo. 
 Full morphology catalogs and all galaxy images are available from the `Galaxy Zoo DECaLS data release Zenodo deposit <https://doi.org/10.5281/zenodo.4196266>`_.
 
 Weights
@@ -22,7 +22,7 @@ All models are trained on a dataset split into 70% training, 10% validation (for
 This is denoted by ``train_only_dr5`` in the name.
 To verify that the TensorFlow/PyTorch versions of Zoobot perform similarly, the split is the same for both versions and all models.
 
-The exact training scripts are in the `replication <https://github.com/mwalmsley/zoobot/tree/pytorch/replication>`_ folder.
+The exact training scripts are in the `replication <https://github.com/mwalmsley/zoobot/tree/main/replication>`_ folder.
 These record important details like batch size, mixed precision, etc.
 
 See :ref:`the DECaLS guide <training_from_scratch>` for pedagogical details on how to train models from scratch and how you might train on new Galaxy Zoo campaigns.
@@ -85,7 +85,7 @@ The galaxies can be cross-matched to the Galaxy Zoo 2 catalogues on the "id_str"
     The representations have 1280 features per galaxy. These features are highly redundant (because the CNN has no reason to make them independent).
     They can be effectively compressed by e.g. PCA into around ~40 features while preserving ~95% of the variation.
     The compressed representations are much more practical to work with for e.g. clustering, anomaly-finding, active learning, visualisation with umap, etc.
-    See `this example <https://github.com/mwalmsley/zoobot/tree/pytorch/zoobot/shared/compress_representations.py>`_ for how to compress the representations (essentially, just apply sklearn's ``IterativePCA``).
+    See `this example <https://github.com/mwalmsley/zoobot/blob/main/zoobot/shared/compress_representations.py>`_ for how to compress the representations (essentially, just apply sklearn's ``IterativePCA``).
     See :ref:`representations_guide` for more details on the representations.
 
 
@@ -97,7 +97,7 @@ We have included the code used to carry out this fine-tuning in this repository,
 You might like to improve on our work or to use this as a starting point to be swapped out for your own target galaxies.
 
 To carry out the fine-tuning with our example scripts, you will need the catalogues of labelled rings and the images.
-This repository includes two catalogues under `data <https://github.com/mwalmsley/zoobot/tree/pytorch/data>`_ : ``example_ring_catalog_basic.csv`` and ``example_ring_catalog_advanced.parquet``.
+This repository includes two catalogues under `data <https://github.com/mwalmsley/zoobot/tree/main/data>`_ : ``example_ring_catalog_basic.csv`` and ``example_ring_catalog_advanced.parquet``.
 
 ``example_ring_catalog_basic.csv`` is a basic catalogue used for demonstration purposes in ``finetune_minimal.py``.
 Ring labels are assigned depending on if each GZD-5 galaxy was tagged as "ring" by any volunteers on the Galaxy Zoo forum. 

--- a/docs/guides/finetuning.rst
+++ b/docs/guides/finetuning.rst
@@ -27,7 +27,7 @@ If you do want to start from scratch, to reproduce or improve upon the pretraine
     This guide uses code for the TensorFlow version of Zoobot.
     The conceptual approach is exactly the same with the PyTorch version.
     I haven't written examples yet - sorry! 
-    For now, here are two links for fine-tuning vision models with `PyTorch Vision <https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/domain_templates/computer_vision_fine_tuning.py>`__ and `PyTorch Lightning <https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/domain_templates/computer_vision_fine_tuning.py>`__.
+    For now, here are two links for fine-tuning vision models with `PyTorch Vision <>`__ and `PyTorch Lightning <https://github.com/Lightning-AI/lightning/blob/master/examples/pl_domain_templates/computer_vision_fine_tuning.py>`__.
 
 
 Examples

--- a/docs/guides/pytorch_or_tensorflow.rst
+++ b/docs/guides/pytorch_or_tensorflow.rst
@@ -5,7 +5,7 @@
 PyTorch or TensorFlow?
 ===========================
 
-Zoobot is really two separate sets of code: `zoobot/pytorch <https://github.com/mwalmsley/zoobot/tree/pytorch/zoobot/pytorch>`_ and `zoobot/tensorflow <https://github.com/mwalmsley/zoobot/tree/pytorch/zoobot/tensorflow>`_.
+Zoobot is really two separate sets of code: `zoobot/pytorch <https://github.com/mwalmsley/zoobot/tree/main/zoobot/pytorch>`_ and `zoobot/tensorflow <https://github.com/mwalmsley/zoobot/tree/main/zoobot/tensorflow>`_.
 They both do (almost) exactly the same thing - train the same model architecture on the same Galaxy Zoo data in the same way, for extracting representations and for finetuning - but they use different underlying deep learning frameworks to do so.
 
 We have created two versions of Zoobot so that you can use your preferred framework.
@@ -30,7 +30,7 @@ This makes training more flexible: with shards, changing the training data requi
 Avoiding shards also saves disk space: TFRecord shards take much up more disk space than the original images.
 
 The TensorFlow version has been around longer.
-It has more working examples (see https://github.com/mwalmsley/zoobot/tree/pytorch/zoobot/tensorflow/examples>`_).
+It has more working examples (see `<https://github.com/mwalmsley/zoobot/tree/main/zoobot/tensorflow/examples>`_).
 It has also been used in published work: both the GZ DECaLS catalog and the "practical representation tools" paper used the TensorFlow version.
 
 The PyTorch version is new and includes the latest features but has less examples and documentation and has not yet been formally published.

--- a/docs/guides/training_from_scratch.rst
+++ b/docs/guides/training_from_scratch.rst
@@ -157,7 +157,7 @@ See the :ref:`Training with TensorFlow <training_with_tensorflow>` guide.
     I will also adjust the model to not include these preprocessing layers, to allow more flexibilty with stochastic adjustments.
     Any help would be very welcome and would be credited appropriately.
 
-With the PyTorch version, you need to define a `PyTorch Lightning DataModule <https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html>`_ that describes how to load the images listed in your catalog and how to divide them into train/validation/test sets. 
+With the PyTorch version, you need to define a `PyTorch Lightning DataModule <https://pytorch-lightning.readthedocs.io/en/stable/notebooks/lightning_examples/datamodules.html>`_ that describes how to load the images listed in your catalog and how to divide them into train/validation/test sets. 
 To train as fast as possible, any static adjustments should already have been done to those images.
 Stochastic adjustments happen when the images are read from those paths into memory, using the PyTorch dataloaders you define in your DataModule.
 See the :ref:`Training with PyTorch <training_with_pytorch>` guide.

--- a/docs/guides/training_with_pytorch.rst
+++ b/docs/guides/training_with_pytorch.rst
@@ -8,8 +8,8 @@ For training from scratch with either TensorFlow or PyTorch, you should have fir
 Creating a DataModule
 ----------------------
 
-With the PyTorch version, you need to define a `PyTorch Lightning DataModule <https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html>`_ that describes how to load the images listed in your catalog and how to divide them into train/validation/test sets. 
-See `zoobot/pytorch/datasets/decals_dr8.py <https://github.com/mwalmsley/zoobot/blob/main/zoobot/pytorch/datasets/decals_dr8.py>`_ for a working example to adjust. 
+With the PyTorch version, you need to define a `PyTorch Lightning DataModule <https://pytorch-lightning.readthedocs.io/en/stable/notebooks/lightning_examples/datamodules.html>`_ that describes how to load the images listed in your catalog and how to divide them into train/validation/test sets. 
+See `pytorch-galaxy-datasets <https://github.com/mwalmsley/pytorch-galaxy-datasets/blob/main/pytorch_galaxy_datasets/deprecated/decals_dr8.py>`_ for a working example to adjust. 
 
 .. note:: 
 
@@ -62,7 +62,7 @@ There are two complete working examples which you can copy and adapt. Both scrip
 This example provides the whole catalog to ``train_with_pytorch_lightning.train``, which then automatically splits it into train/validation/test subsets.
 You will need to provide your own catalog. I will add an example volunteer catalog to the ``data`` folder at some point TODO
 
-`replication/pytorch/train_model_on_decals_dr5_splits.py <https://github.com/mwalmsley/zoobot/blob/main/zoobot/tensorflow/examples/train_model.py>`__
+`replication/pytorch/train_model_on_decals_dr5_splits.py <https://github.com/mwalmsley/zoobot/blob/main/replication/pytorch/train_model_on_decals_dr5_splits.py>`__
 demonstrates training a model on a volunteer catalog already split into train/validation/test subsets, but is otherwise very similar.
 This example is the script used to create the pretrained models shared under :ref:`datanotes`.
 

--- a/docs/guides/training_with_tensorflow.rst
+++ b/docs/guides/training_with_tensorflow.rst
@@ -32,7 +32,7 @@ Training on Shards
 --------------------
 
 Now you can train a CNN using those shards. 
-`train_with_keras.py <https://github.com/mwalmsley/zoobot/blob/main/zoobot/training/train_with_keras.py>`__ has the code to do this.
+`train_with_keras.py <https://github.com/mwalmsley/zoobot/blob/main/zoobot/tensorflow/training/train_with_keras.py>`__ has the code to do this.
 This has a .train() function with the following arguments:
 
 .. code-block:: python
@@ -68,10 +68,10 @@ Check the function docstring (and comments in the function itself) for further d
 
 There are two complete working examples which you can copy and adapt. Both scripts are simply convenient command-line wrappers around ``train_with_keras.train``.
 
-`zoobot/tensorflow/examples/train_model_on_shards.py <https://github.com/mwalmsley/zoobot/blob/main/zoobot/tensorflow/examples/train_model_on_catalog.py>`__ demonstrates training a model on shards you've created. 
+`zoobot/tensorflow/examples/train_model_on_shards.py <https://github.com/mwalmsley/zoobot/blob/main/zoobot/tensorflow/examples/train_model_on_shards.py>`__ demonstrates training a model on shards you've created. 
 You can use the shards created by the worked example in the section above.
 
-`replication/tensorflow/train_model_on_decals_dr5_splits.py <https://github.com/mwalmsley/zoobot/blob/main/zoobot/tensorflow/examples/train_model.py>`__
+`replication/tensorflow/train_model_on_decals_dr5_splits.py <https://github.com/mwalmsley/zoobot/blob/main/replication/tensorflow/train_model_on_decals_dr5_splits.py>`__
 trains a model on the shards used by W+22a (themselves created by `decals_dr5_to_shards.py <https://github.com/mwalmsley/zoobot/blob/main/zoobot/tensorflow/examples/decals_dr5_to_shards.py>`__).
 This example is the script used to create the pretrained TensorFlow models shared under :ref:`datanotes`.
 


### PR DESCRIPTION
This PR is to update some of the broken links in the documentation.
All (new) links might not have been covered, especially considering the heavy development over the past few days!

Note: There is one place where I couldn't find a suitable replacement, which is the reference for PyTorch Vision (L30 of `docs/guides/finetuning.rst`). Would appreciate a link to put here!