### PR TITLE
remove extra `_non-star` label for artifact task

### DIFF
--- a/zoobot/shared/label_metadata.py
+++ b/zoobot/shared/label_metadata.py
@@ -196,7 +196,7 @@ cosmic_dawn_ortho_pairs = {
     'merging-cd': ['_none', '_minor-disturbance', '_major-disturbance', '_merger'],
     'clumps-cd': ['_yes', '_no'],
     'problem-cd': ['_star', '_artifact', '_zoom'],
-    'artifact-cd': ['_non-star', '_satellite', '_scattered', '_diffraction', '_ray', '_saturation', '_other']
+    'artifact-cd': ['_satellite', '_scattered', '_diffraction', '_ray', '_saturation', '_other']
 }
 
 cosmic_dawn_ortho_dependencies = {


### PR DESCRIPTION
T15 `artifact` only has 6 answers in the workflow, i'm not sure where this data column came from, perhaps an older workflow version? 

It appears this is in the test aggregation results for GZ CD workflow id 21802 but i'm wondering if it's meant to be here. 

If it is then close this PR and i'll make sure to update the KaDE catalogue outputs to include this column even though we won't have derived data as the answer isn't in the current workflow setup.
```
{
  "T15": {
    "help": "There are multiple types of artifacts that.....",
    "type": "single",
    "answers": [
      {
        "label": "![artifact_bleed_trail_larger.png](https://panoptes-uploads.zooniverse.org/project_attached_image/7c826151-ae85-4151-b907-90aceae04f95.png =60x) Saturation Feature (Bleed Trail)"
      },
      {
        "label": "![artifact_diffraction_spike_larger.png](https://panoptes-uploads.zooniverse.org/project_attached_image/c5b86f1b-c1b3-46e7-83a1-76f9d2f64026.png =60x) Diffraction Spike"
      },
      {
        "label": "![artifact_satellite_trail.png](https://panoptes-uploads.zooniverse.org/project_attached_image/b5baf964-6f64-4d67-b60d-bc203ca7f971.png =60x) Satellite Trail"
      },
      {
        "label": "![artifact_cosmic_ray_larger.png](https://panoptes-uploads.zooniverse.org/project_attached_image/3f3c9590-74c8-4e67-b77c-1bc80a7a4312.png =60x) Cosmic Ray"
      },
      {
        "label": "![artifact_scattered_light.png](https://panoptes-uploads.zooniverse.org/project_attached_image/61aef8bd-7f4a-4074-9d43-49d5c927df5b.png =60x) Scattered Light"
      },
      {
        "label": "![artifact_other_mix.png](https://panoptes-uploads.zooniverse.org/project_attached_image/d0d98935-4686-4b40-9353-c910b7539ef8.png =60x) Other / Not Sure"
      }
    ],
    "question": "What type of artifact is it?",
    "required": true
  }
}
```