### PR TITLE
add wandb logging, freeze batchnorm by default

### DIFF
--- a/zoobot/pytorch/examples/finetuning/finetune_counts_full_tree.py
+++ b/zoobot/pytorch/examples/finetuning/finetune_counts_full_tree.py
@@ -38,17 +38,18 @@ if __name__ == '__main__':
         max_galaxies = None
     else:  # test locally
         repo_dir = '/home/walml/repos'
-        accelerator = 'cpu'
+        accelerator = 'gpu'
         devices = None
-        batch_size = 64
+        batch_size = 32
         prog_bar = True
-        max_galaxies = 256
+        # max_galaxies = 256
+        max_galaxies = None
 
     # TODO not yet made public
     # pd.DataFrame with columns 'id_str' (unique id), 'file_loc' (path to image),
     # and label_cols (e.g. smooth-or-featured-cd_smooth) with count responses
     df = pd.read_parquet(os.path.join(
-        repo_dir, 'zoobot/data/gz_cosmic_dawn_early_aggregation_with_file_locs_ortho.parquet'))
+        repo_dir, 'zoobot/data/gz_cosmic_dawn_early_aggregation_ortho_with_file_locs.parquet'))
     # sometimes auto-cast to float, which causes issue when saving hdf5
     df['id_str'] = df['id_str'].astype(str)
 
@@ -70,7 +71,7 @@ if __name__ == '__main__':
         },
         'finetune': {
             'encoder_dim': 1280,
-            'n_epochs': 50,
+            'n_epochs': 100,
             'n_layers': 2,
             'label_dim': len(schema.label_cols),
             'label_mode': 'count',
@@ -96,10 +97,14 @@ if __name__ == '__main__':
 
     save_dir = os.path.join(
         repo_dir, f'gz-decals-classifiers/results/finetune_{np.random.randint(1e8)}')
-    
+
+    # can do logger=None or, to use wandb:
+    from pytorch_lightning.loggers import WandbLogger
+    logger = WandbLogger(project='finetune', name='full_tree_example')
+
     # key method
     _, model = finetune.run_finetuning(
-        config, encoder, datamodule, save_dir=save_dir, logger=None)
+        config, encoder, datamodule, save_dir=save_dir, logger=logger)
 
     # now save predictions on test set to evaluate performance
   

--- a/zoobot/pytorch/training/finetune.py
+++ b/zoobot/pytorch/training/finetune.py
@@ -12,10 +12,20 @@ import torch
 from torch import Tensor
 import torch.nn.functional as F
 import torchmetrics as tm
-# from einops import rearrange
 
 from zoobot.pytorch.estimators import efficientnet_custom
 from zoobot.pytorch.training import losses
+
+# https://discuss.pytorch.org/t/how-to-freeze-bn-layers-while-training-the-rest-of-network-mean-and-var-wont-freeze/89736/7
+# I do this recursively and only for BatchNorm2d (not dropout, which I still want active)
+def freeze_batchnorm_layers(model):
+      for name, child in (model.named_children()):
+        if isinstance(child, torch.nn.BatchNorm2d):
+            logging.info('freezing {} {}'.format(child, name))
+            child.eval()  # no grads, no param updates, no statistic updates
+        else:
+          freeze_batchnorm_layers(child)  # recurse
+
 
 
 class FinetunedZoobotLightningModule(pl.LightningModule):
@@ -30,6 +40,7 @@ class FinetunedZoobotLightningModule(pl.LightningModule):
         batch_size=1024,
         lr_decay=0.75,
         dropout_prob=0.5,
+        freeze_batchnorm=True,
         prog_bar=True,
         seed=42,
         label_mode='classification',  # or 'counts'
@@ -37,7 +48,8 @@ class FinetunedZoobotLightningModule(pl.LightningModule):
     ):
         super().__init__()
 
-        # adds to model.hparams
+        # adds every __init__ arg to model.hparams
+        # will also add to wandb if using logging=wandb, I think
         # necessary if you want to reload!
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -59,6 +71,11 @@ class FinetunedZoobotLightningModule(pl.LightningModule):
         self.train_acc = None
         self.val_acc = None
         self.test_acc = None
+
+        self.freeze_batchnorm = freeze_batchnorm
+
+        if self.freeze_batchnorm:
+            freeze_batchnorm_layers(self.encoder)  # inplace
 
         if label_mode == 'classification':
             logging.info('Using classification head and cross-entropy loss')
@@ -87,28 +104,14 @@ class FinetunedZoobotLightningModule(pl.LightningModule):
 
     def forward(self, x: Tensor) -> Tensor:
         x = self.encoder(x)
-        # x = rearrange(x, "b c h w -> b (c h w)")
         x = self.head(x)
         return x
-
-    # def on_fit_start(self):
-
-    #     # Log size of data-sets
-    #     # TODO review if this works for mine
-    #     # logging_params = {key: len(value) for key, value in self.trainer.datamodule.data.items()}
-    #     # self.logger.log_hyperparams(logging_params)
-    #     if self.logger is not None:
-    #         # hopefully this exists?
-    #         self.logger.log({'train_dataset_size': len(
-    #             self.trainer.train_datamodule())})
 
     def training_step(self, batch, batch_idx):
         # Load data and targets
         x, y = batch
         y_pred = self.forward(x)
-        # self.train_acc(y_pred, y)
         loss = self.loss(y, y_pred)
-        # self.log("finetuning/train_acc", self.train_acc, on_step=False, on_epoch=True, prog_bar=self.prog_bar)
         return {'loss': loss, 'preds': y_pred, 'targets': y}
 
     def on_train_batch_end(self, outputs, *args) -> None:
@@ -122,7 +125,6 @@ class FinetunedZoobotLightningModule(pl.LightningModule):
     def validation_step(self, batch, batch_idx, dataloader_idx=0):
         x, y = batch
         y_pred = self.forward(x)
-        # self.val_acc(y_pred, y)
         loss = self.loss(y, y_pred)
         return {'loss': loss, 'preds': y_pred, 'targets': y}
 
@@ -151,7 +153,7 @@ class FinetunedZoobotLightningModule(pl.LightningModule):
     def configure_optimizers(self):
         if self.freeze:
             params = self.head.parameters()
-            # adam not adamW
+            # using adam not adamW for now - TODO config/hparam?
             return torch.optim.Adam(params, lr=1e-4)
         else:
             # lr = 0.001 * self.batch_size / 256
@@ -224,7 +226,7 @@ def run_finetuning(config, encoder, datamodule, save_dir, logger=None):
     early_stopping_callback = EarlyStopping(
       monitor='finetuning/val_loss',
       mode='min',
-      patience=5
+      patience=15
     )
 
     ## Initialise pytorch lightning trainer ##
@@ -240,12 +242,10 @@ def run_finetuning(config, encoder, datamodule, save_dir, logger=None):
 
     trainer.fit(model, datamodule)
 
+    # when ready (don't peek often, you'll overfit)
     # trainer.test(model, dataloaders=datamodule)
 
     return checkpoint_callback.best_model_path, model
-
-
-
 
 
 


### PR DESCRIPTION
Doing some polishing on finetuning
- Add wandb logging to the full_tree example. @camallen use this for dashboard. You will need to add import wandb, wandb.init(authkey, etc) just before when running on Azure.
- Freeze batch norm layers by default when finetuning, with new recursive function
- Pass additional params via config (thanks Cam)
- Minor cleanup